### PR TITLE
ci: route linux x64 jobs to self-hosted podman fleet

### DIFF
--- a/.github/workflows/bench-workspace.yml
+++ b/.github/workflows/bench-workspace.yml
@@ -28,7 +28,7 @@ jobs:
   # Benchmark all packages with criterion
   benchmark:
     name: Benchmark (${{ matrix.package }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -155,7 +155,7 @@ jobs:
   # Compare with baseline on main branch
   compare-baseline:
     name: Compare with Baseline
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: benchmark
     if: github.event_name == 'pull_request'
     timeout-minutes: 10
@@ -209,7 +209,7 @@ jobs:
   # Update baseline on main branch
   update-baseline:
     name: Update Baseline
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: benchmark
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     timeout-minutes: 10
@@ -260,7 +260,7 @@ jobs:
   # Performance dashboard data export
   export-metrics:
     name: Export Performance Metrics
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: benchmark
     if: github.ref == 'refs/heads/main'
     timeout-minutes: 10

--- a/.github/workflows/ci-workspace.yml
+++ b/.github/workflows/ci-workspace.yml
@@ -40,7 +40,7 @@ jobs:
   # Quick format check - fails fast
   format-check:
     name: Format Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
   # Matrix-based parallel testing
   test:
     name: Test (${{ matrix.package }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 15
     needs: format-check
     strategy:
@@ -138,7 +138,7 @@ jobs:
   # Integration tests are now part of embeddenator-testkit (--features integration)
   integration-tests:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 20
     needs: test
     steps:
@@ -183,7 +183,7 @@ jobs:
   # Workspace health check using embeddenator-workspace tool
   health-check:
     name: Workspace Health Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 10
     needs: test
     steps:
@@ -236,7 +236,7 @@ jobs:
   # Version consistency check
   version-check:
     name: Version Consistency
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 5
     needs: format-check
     steps:
@@ -262,7 +262,7 @@ jobs:
   # Documentation build - ensures all docs build without warnings
   docs:
     name: Documentation Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 15
     needs: test
     steps:
@@ -304,7 +304,7 @@ jobs:
   # Multi-version Rust testing
   rust-versions:
     name: Rust ${{ matrix.rust }} (${{ matrix.package }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 15
     needs: format-check
     strategy:
@@ -348,7 +348,7 @@ jobs:
   # Final status check
   ci-success:
     name: CI Success
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [format-check, test, integration-tests, health-check, version-check, docs, rust-versions]
     if: always()
     steps:

--- a/.github/workflows/docs-workspace.yml
+++ b/.github/workflows/docs-workspace.yml
@@ -24,7 +24,7 @@ jobs:
   # Build all documentation
   build-docs:
     name: Build Documentation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -231,7 +231,7 @@ jobs:
   # Deploy to GitHub Pages (only on main branch)
   deploy:
     name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: build-docs
     if: github.ref == 'refs/heads/main'
     environment:
@@ -245,7 +245,7 @@ jobs:
   # Check documentation coverage
   doc-coverage:
     name: Documentation Coverage
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/health-workspace.yml
+++ b/.github/workflows/health-workspace.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   health-check:
     name: Run Health Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -179,7 +179,7 @@ jobs:
   # Git status check
   git-status:
     name: Git Repository Status
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-workspace.yml
+++ b/.github/workflows/release-workspace.yml
@@ -33,7 +33,7 @@ jobs:
   # Validate release readiness
   validate:
     name: Validate Release Readiness
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 10
     outputs:
       can_release: ${{ steps.check.outputs.can_release }}
@@ -106,7 +106,7 @@ jobs:
   # Bump versions
   bump-versions:
     name: Bump Versions
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: validate
     if: needs.validate.outputs.can_release == 'true'
     timeout-minutes: 15
@@ -189,7 +189,7 @@ jobs:
   # Build release artifacts
   build-artifacts:
     name: Build Release Artifacts (${{ matrix.target }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'macos-latest' && 'macos-latest' || fromJSON('["self-hosted", "linux", "x64", "podman"]') }}
     needs: bump-versions
     if: github.event.inputs.dry_run != 'true'
     timeout-minutes: 30
@@ -251,7 +251,7 @@ jobs:
   # Create GitHub release
   create-release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [bump-versions, build-artifacts]
     if: github.event.inputs.dry_run != 'true'
     timeout-minutes: 10
@@ -300,7 +300,7 @@ jobs:
   # Publish to crates.io
   publish-crates:
     name: Publish to crates.io
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [bump-versions, create-release]
     if: github.event.inputs.dry_run != 'true'
     timeout-minutes: 30

--- a/.github/workflows/security-workspace.yml
+++ b/.github/workflows/security-workspace.yml
@@ -22,7 +22,7 @@ jobs:
   # Audit dependencies for known vulnerabilities
   cargo-audit:
     name: Cargo Audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
   # Check for outdated dependencies
   cargo-outdated:
     name: Check Outdated Dependencies
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -164,7 +164,7 @@ jobs:
   # Clippy with security lints
   clippy-security:
     name: Clippy Security Lints
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -208,7 +208,7 @@ jobs:
   # Check license compliance
   license-check:
     name: License Compliance
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Adapts GitHub Actions workflows to run on the shared **gha-runner-ctl** fleet on the WSL workstation.

## Changes
- Replace `runs-on: ubuntu-latest` with `runs-on: [self-hosted, linux, x64, podman]` for linux x64 jobs
- Matrix/release jobs: linux targets use fleet labels; macOS/Windows/ARM64 labels unchanged
- No trigger or permission changes

## Post-merge (orchestrator)
- Add `tzervas/embeddenator` to `GHA_PREFER_REPOS` on the fleet host
- Run `gha-runner-ctl warm --start` or reboot WSL to pick up demand

## Validation
After merge: `workflow_dispatch` the primary CI workflow and confirm the job schedules on the fleet runner.