### PR TITLE
fix(ci): embeddenator-core in workspace CI matrices and repo paths

### DIFF
--- a/.github/workflows/ci-workspace.yml
+++ b/.github/workflows/ci-workspace.yml
@@ -24,7 +24,7 @@ env:
   RUST_LOG: ${{ inputs.debug_mode && 'debug' || '' }}
   # Repositories to test
   REPOS: >
-    embeddenator
+    embeddenator-core
     embeddenator-cli
     embeddenator-contract-bench
     embeddenator-fs
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - embeddenator
+          - embeddenator-core
           - embeddenator-cli
           - embeddenator-contract-bench
           - embeddenator-fs
@@ -363,7 +363,7 @@ jobs:
       - name: Generate coverage
         run: |
           repos=(
-            embeddenator
+            embeddenator-core
             embeddenator-cli
             embeddenator-contract-bench
             embeddenator-fs

--- a/.github/workflows/docs-workspace.yml
+++ b/.github/workflows/docs-workspace.yml
@@ -45,7 +45,7 @@ jobs:
           export RUSTDOCFLAGS="-D warnings"
           
           repos=(
-            embeddenator
+            embeddenator-core
             embeddenator-cli
             embeddenator-contract-bench
             embeddenator-fs

--- a/.github/workflows/health-workspace.yml
+++ b/.github/workflows/health-workspace.yml
@@ -206,7 +206,7 @@ jobs:
           echo "Checking branch synchronization..."
           
           repos=(
-            embeddenator
+            embeddenator-core
             embeddenator-cli
             embeddenator-contract-bench
             embeddenator-fs

--- a/.github/workflows/release-workspace.yml
+++ b/.github/workflows/release-workspace.yml
@@ -85,7 +85,7 @@ jobs:
           echo "Running full test suite..."
           
           repos=(
-            embeddenator
+            embeddenator-core
             embeddenator-cli
             embeddenator-contract-bench
             embeddenator-fs
@@ -226,7 +226,7 @@ jobs:
       
       - name: Build release binary
         run: |
-          cargo build --release --target ${{ matrix.target }} -p embeddenator
+          cargo build --release --target ${{ matrix.target }} -p embeddenator-core
           cargo build --release --target ${{ matrix.target }} -p embeddenator-cli
           cargo build --release --target ${{ matrix.target }} -p embeddenator-workspace
       
@@ -328,7 +328,7 @@ jobs:
             "embeddenator-contract-bench"
             "embeddenator-cli"
             "embeddenator-workspace"
-            "embeddenator"
+            "embeddenator-core"
           )
           
           for package in "${packages[@]}"; do

--- a/.github/workflows/security-workspace.yml
+++ b/.github/workflows/security-workspace.yml
@@ -38,7 +38,7 @@ jobs:
         continue-on-error: true
         run: |
           repos=(
-            embeddenator
+            embeddenator-core
             embeddenator-cli
             embeddenator-contract-bench
             embeddenator-fs
@@ -133,7 +133,7 @@ jobs:
           echo "" >> outdated-report.md
           
           repos=(
-            embeddenator
+            embeddenator-core
             embeddenator-cli
             embeddenator-contract-bench
             embeddenator-fs
@@ -182,7 +182,7 @@ jobs:
       - name: Run Clippy with security lints
         run: |
           repos=(
-            embeddenator
+            embeddenator-core
             embeddenator-cli
             embeddenator-contract-bench
             embeddenator-fs
@@ -270,7 +270,7 @@ jobs:
           echo "" >> license-report.md
           
           repos=(
-            embeddenator
+            embeddenator-core
             embeddenator-cli
             embeddenator-contract-bench
             embeddenator-fs


### PR DESCRIPTION
## Summary

The superproject renamed the umbrella crate directory from `embeddenator` to `embeddenator-core` (`Cargo.toml` package name: `embeddenator-core`). Several workspace workflows still referenced the old path/name, causing matrix jobs to `cd embeddenator` into a non-existent directory.

`bench-workspace.yml` already used `embeddenator-core`; this aligns the rest.

## Changes

- `ci-workspace.yml`: `REPOS`, test matrix `package`, coverage repo list
- `health-workspace.yml`: git-status repo list
- `security-workspace.yml`: audit/outdated/clippy/license repo lists
- `docs-workspace.yml`: doc build repo list
- `release-workspace.yml`: validate test repos, `cargo build -p embeddenator-core`, crates.io publish directory list

## Validation

Dry-validated all six workflow YAML files with `yaml.safe_load_all` (PyYAML) — all parse OK.

## Scope

Workflow matrix/package paths only (no embeddenator-core Phase 3 or sibling crate changes).